### PR TITLE
Change for invoking SecretKeySpec.destroy()

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -4,10 +4,10 @@
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
-        <option name="delegatedBuild" value="false" />
         <option name="testRunner" value="GRADLE" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
+        <option name="gradleJvm" value="11" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -46,7 +46,7 @@
       </value>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_11" default="true" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,7 +2,7 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/SmartList.iml" filepath="$PROJECT_DIR$/SmartList.iml" />
+      <module fileurl="file://$PROJECT_DIR$/.idea/modules/SmartList.iml" filepath="$PROJECT_DIR$/.idea/modules/SmartList.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/app/SmartList.app.iml" filepath="$PROJECT_DIR$/.idea/modules/app/SmartList.app.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/custom-dialog-add-delete-1.0/SmartList.custom-dialog-add-delete-1.0.iml" filepath="$PROJECT_DIR$/.idea/modules/custom-dialog-add-delete-1.0/SmartList.custom-dialog-add-delete-1.0.iml" />
       <module fileurl="file://$PROJECT_DIR$/.idea/modules/custom-dialog-currency-picker-1_0/SmartList.custom-dialog-currency-picker-1_0.iml" filepath="$PROJECT_DIR$/.idea/modules/custom-dialog-currency-picker-1_0/SmartList.custom-dialog-currency-picker-1_0.iml" />

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
+    compileSdkVersion 29
     buildToolsVersion "29.0.2"
     defaultConfig {
         applicationId "com.development.smartlist"
         minSdkVersion 23
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/app/src/main/java/com/development/smartlist/SQLiteContentProvider.java
+++ b/app/src/main/java/com/development/smartlist/SQLiteContentProvider.java
@@ -1,7 +1,7 @@
 /*------------------------------------------------------------------------------------------
  |              Class: SQLiteContentProvider.java
  |             Author: Jon Bateman
- |            Version: 1.2.2
+ |            Version: 1.2.3
  |
  |            Purpose: Content Provider used for interacting with a SQLite database. Targeted
  |                     database name is passed as a URI parameter so that the relevant DBHelper
@@ -41,6 +41,8 @@ import android.os.Bundle;
 import android.util.Base64;
 import android.util.Log;
 import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidAlgorithmParameterException;
 import java.security.InvalidKeyException;
@@ -56,7 +58,6 @@ import javax.crypto.IllegalBlockSizeException;
 import javax.crypto.NoSuchPaddingException;
 import javax.crypto.spec.GCMParameterSpec;
 import javax.crypto.spec.SecretKeySpec;
-import javax.security.auth.DestroyFailedException;
 
 public class SQLiteContentProvider extends ContentProvider {
 
@@ -458,11 +459,13 @@ public class SQLiteContentProvider extends ContentProvider {
                 accessAllowed = true;
             }
 
-            // Ensure sensitive information does not persist.
+            // SecretKeySpec.destroy() method is an optional method. Not all implementations of SecretKey
+            // implement it.
             try {
-                sKeySpec.destroy();
-            } catch (DestroyFailedException dfe) {
-                // Ignore
+                Method method = SecretKeySpec.class.getMethod("destroy"); // (Class<?>[]) null
+                method.invoke(sKeySpec);
+            } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+                // ignore
             }
 
             Arrays.fill(decodedDecryptedParameterByte, 0, decodedDecryptedParameterByte.length - 1, (byte) 0);


### PR DESCRIPTION
Not all implementations of SecretKey have the destroy() method.